### PR TITLE
支部マップ運用変更につきREADME更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # JAWSUG_Map
-JAWSUG 支部マップです
+JAWSUG 支部マップです。  
+マップのもととなる支部一覧は https://jaws-ug.jp/act/ が最新・マスターです。  
+マップへの追加・変更・削除の依頼は、Slackにて事務局 広報チームまでお知らせください。
 
 ## データ
 
+* jaws-ug-map.pptx : パワーポイント用データ（支部マップマスター）  
+--- 注）以下は更新されていない可能性があります ---
 * jaws-ug-map.ai : Adobe Illustrator CC(2014) CMYKデータ
 * jaws-ug-map-english.ai : 上記の英語データ
 * jaws-ug-map.png : 上記の png データ
 * jaws-ug-map-english.png : 上記の英語の png データ
 * jaws-ug-map_bg_white.png : 上記の png データ(背景ホワイト)
 * jaws-ug-map.pdf : 上記の　PDF データ
-* jaws-ug-map.pptx : パワーポイント用データ
 
 ## ライセンス
 <a rel="license" href="http://creativecommons.org/licenses/by-nc/4.0/"><img alt="クリエイティブ・コモンズ・ライセンス" style="border-width:0" src="https://i.creativecommons.org/l/by-nc/4.0/88x31.png" /></a>


### PR DESCRIPTION
事務局MTGでの決定事項を反映しました。

- HPの勉強会グループ一覧( https://jaws-ug.jp/act/ )をマスターとしてマップを更新する
- マップデータのマスターは.pptxとする
- 更新について
  - いつ(定期更新)：総会（Days）前、Summit前、(随時更新): 要望が出たら
  - だれが：広報チーム
  - どのように: チケットベースで
